### PR TITLE
move devDependencies: pad, iso-7064 and es6-error to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "validate-cnj",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -414,8 +414,7 @@
     "clone": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-      "dev": true
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
     },
     "color-convert": {
       "version": "1.9.3",
@@ -505,7 +504,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
-      "dev": true,
       "requires": {
         "clone": "^1.0.2"
       }
@@ -582,8 +580,7 @@
     "es6-error": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-      "dev": true
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -1249,8 +1246,7 @@
     "iso-7064": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/iso-7064/-/iso-7064-1.0.2.tgz",
-      "integrity": "sha512-3I7HvuGa8eyxw5r+C6QldcLrwlc9H58OJUXxvbwOeEloelaSC/8StTbybcgsFpsOnshp6oLjKbUFnIg7SmyTPA==",
-      "dev": true
+      "integrity": "sha512-3I7HvuGa8eyxw5r+C6QldcLrwlc9H58OJUXxvbwOeEloelaSC/8StTbybcgsFpsOnshp6oLjKbUFnIg7SmyTPA=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -1706,7 +1702,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/pad/-/pad-3.2.0.tgz",
       "integrity": "sha512-2u0TrjcGbOjBTJpyewEl4hBO3OeX5wWue7eIFPzQTg6wFSvoaHcBTTUY5m+n0hd04gmTCPuY0kCpVIVuw5etwg==",
-      "dev": true,
       "requires": {
         "wcwidth": "^1.0.1"
       }
@@ -2293,7 +2288,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
       "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
-      "dev": true,
       "requires": {
         "defaults": "^1.0.3"
       }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,11 @@
   "author": {
     "name": "lf.amorim@bipbop.com.br"
   },
-  "dependencies": {},
+  "dependencies": {
+    "es6-error": "^4.1.1",
+    "iso-7064": "^1.0.2",
+    "pad": "^3.2.0"
+  },
   "types": "index.d.ts",
   "files": [
     "index.d.ts",
@@ -12,14 +16,11 @@
   "description": "Validador da numeração CNJ escrito em JavaScript com suporte para navegadores, pegar e usar.",
   "devDependencies": {
     "chai": "^4.2.0",
-    "es6-error": "^4.1.1",
     "eslint": "^6.8.0",
     "eslint-config-airbnb-base": "^14.1.0",
     "eslint-config-airbnb-es5": "^1.2.0",
     "eslint-plugin-import": "^2.20.2",
-    "iso-7064": "^1.0.2",
     "mocha": "^7.1.1",
-    "pad": "^3.2.0",
     "rimraf": "^3.0.2",
     "rollup": "^2.3.0",
     "@rollup/plugin-buble": "^0.21.1",


### PR DESCRIPTION
Ao utilizar `npm install --production` as dependência pad, iso-7064 and es6-error  são necessária no modo produção.